### PR TITLE
Feature/aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,31 @@ branches:
 
 language: rust
 
+rust:
+# build nightly only for the time beeing
+  - nightly
+
 matrix:
   fast_finish: true
-
   include:
-    - rust: nightly
+    - name: "build 64Bit"
+      install:
+        - sudo apt-get install gcc-aarch64-linux-gnu gcc-aarch64-linux-gnu
+        - cargo install cargo-xbuild
+        - rustup target add aarch64-unknown-linux-gnu
+        - rustup component add rust-src
+        - sudo chmod ugo+x build.sh
+      script: sed -i 's/path.*=.*\".*", version/version/g' Cargo.toml && ./build.sh 64 travis
 
-script: ./travis-build.sh
+    - name: "build 32Bit"
+      install:
+        - sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+        - cargo install cargo-xbuild
+        - rustup target add armv7-unknown-linux-gnueabihf
+        - rustup component add rust-src
+        - sudo chmod ugo+x build.sh
+      # remove the path in the dependencies of the cargo file to ensure we use the version from crates.io
+      script: sed -i 's/path.*=.*\".*", version/version/g' Cargo.toml && ./build.sh 32 travis
 
-install:
-# install cross compiler toolchain
-  - sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
-# install cargo xbuild to proper cross compile  
-  - cargo install cargo-xbuild
-# add the build target used for Raspbarry Pi targeting builds
-  - rustup target add armv7-unknown-linux-gnueabihf
-  - rustup component add rust-src
-  - sudo chmod ugo+x ./travis-build.sh
+    - name: "unit tests"
+      script: sed -i 's/path.*=.*\".*", version/version/g' Cargo.toml && cargo test --tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ruspiro-uart"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.2.0" # remember to update html_root_url
+version = "0.3.0" # remember to update html_root_url
 description = """
 Simple and convinient access API to the Raspberry Pi 3 UART0 (PL011) and UART1 (miniUART) interface
 """
 license = "Apache-2.0"
 repository = "https://github.com/RusPiRo/ruspiro-uart"
-documentation = "https://docs.rs/ruspiro-uart/0.2.0"
+documentation = "https://docs.rs/ruspiro-uart/0.3.0"
 readme = "README.md"
 keywords = ["RusPiRo", "uart", "baremetal", "raspberrypi"]
 categories = ["no-std", "embedded"]
@@ -21,11 +21,12 @@ maintenance = { status = "actively-developed" }
 [lib]
 
 [dependencies]
-ruspiro-gpio = "0.2"
-ruspiro-register = "0.1"
-ruspiro-timer = "0.1"
-ruspiro-console = "0.2"
+ruspiro-gpio = { path = "../gpio", version = "0.3" }
+ruspiro-register = { path = "../register", version = "0.3" }
+ruspiro-timer = { path = "../timer", version = "0.3" }
+ruspiro-console = { path = "../console", version = "0.3" }
 
 [features]
 default = ["ruspiro_pi3"]
-ruspiro_pi3 = []
+ruspiro_pi3 = ["ruspiro-gpio/ruspiro_pi3"]
+with_allocator = ["ruspiro-console/with_allocator"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,11 @@ name = "ruspiro-uart"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
 version = "0.3.0" # remember to update html_root_url
 description = """
-Simple and convinient access API to the Raspberry Pi 3 UART0 (PL011) and UART1 (miniUART) interface
+Simple and convinient access API to the Raspberry Pi 3 UART0 (PL011) and UART1 (miniUART)
+peripherals
 """
 license = "Apache-2.0"
-repository = "https://github.com/RusPiRo/ruspiro-uart"
+repository = "https://github.com/RusPiRo/ruspiro-uart/tree/v0.3.0"
 documentation = "https://docs.rs/ruspiro-uart/0.3.0"
 readme = "README.md"
 keywords = ["RusPiRo", "uart", "baremetal", "raspberrypi"]
@@ -16,7 +17,6 @@ edition = "2018"
 [badges]
 travis-ci = { repository = "RusPiRo/ruspiro-uart", branch = "master" }
 maintenance = { status = "actively-developed" }
-
 
 [lib]
 
@@ -29,4 +29,3 @@ ruspiro-console = { path = "../console", version = "0.3" }
 [features]
 default = ["ruspiro_pi3"]
 ruspiro_pi3 = ["ruspiro-gpio/ruspiro_pi3"]
-with_allocator = ["ruspiro-console/with_allocator"]

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,4 +1,0 @@
-# define specific additional dependencies in addition to the rust core crate when running xargo to create documentation
-# the release build done with cargo xbuild does not need this to properly compile and link all used additional crates
-[target.armv7-unknown-linux-gnueabihf.dependencies]
-alloc = {}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set +ev
+
+if [ $# -eq 0 ] 
+    then 
+        echo "not enough parameter given"
+        exit 1
+fi
+
+# check which aarch version to build
+if [ $1 = "64" ]
+    then
+        # aarch64
+        export CFLAGS='-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53'
+        export RUSTFLAGS='-C linker=aarch64-elf-gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0'
+        if [ "$2" = "" ]
+            then
+                export CC='aarch64-elf-gcc'
+                export AR='aarch64-elf-ar'
+        fi
+        cargo xbuild --target aarch64-unknown-linux-gnu --release
+elif [ $1 = "32" ]
+    then
+        # aarch32
+        export CFLAGS='-mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53'
+        export RUSTFLAGS='-C linker=arm-eabi-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0'
+        if [ -z "$2" ]
+            then
+                export CC='arm-eabi-gcc.exe'
+                export AR='arm-eabi-ar.exe'
+        fi
+        cargo xbuild --target armv7-unknown-linux-gnueabihf --release
+else
+    echo 'provide the archtitecture to be build. Use either "build.sh 32" or "build.sh 64"'
+fi

--- a/makefile
+++ b/makefile
@@ -7,29 +7,29 @@
 # Author: André Borrmann 
 # License: Apache License 2.0
 #******************************************************************
-CARGO_BIN = "$(USER_ROOT)\\.cargo\\bin"
-ARM_GCC_BIN = "$(USER_ROOT)\\arm-gcc\\gcc-arm-eabi\\bin"
-ARM_GCC_LIB = "$(USER_ROOT)\\arm-gcc\\gcc-arm-eabi\\lib\\gcc\\arm-eabi\\8.3.0"
-TARGET = armv7-unknown-linux-gnueabihf
-TARGETDIR = target\\armv7-unknown-linux-gnueabihf\\release
-# environment variables needed by cargo xbuild to use the custom build target
-export CC = arm-eabi-gcc.exe
-export AR = arm-eabi-ar.exe
-export CFLAGS = -std=c11 -mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostartfiles -ffreestanding -mtune=cortex-a53
-export PATH +=  "$(PROJECT_ROOT);$(ARM_GCC_BIN);$(ARM_GCC_LIB);$(CARGO_BIN)"
 
-# build the current crate
-all:  
-# update dependend crates to their latest version if any
-	cargo update
-# cross compile the crate
-	cargo xbuild --lib --target $(TARGET) --release
 
+all32: export CFLAGS = -mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
+all32: export RUSTFLAGS = -C linker=arm-eabi-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0
+all32: export CC = arm-eabi-gcc.exe
+all32: export AR = arm-eabi-ar.exe
+all32: 
+	cargo xbuild --target armv7-unknown-linux-gnueabihf --release
+
+all64: export CFLAGS = -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
+all64: export RUSTFLAGS = -C linker=aarch64-elf-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0
+all64: export CC = aarch64-elf-gcc.exe
+all64: export AR = aarch64-elf-ar.exe
+all64:
+	cargo xbuild --target aarch64-unknown-linux-gnu --release
+
+doc: export CFLAGS = -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
+doc: export RUSTFLAGS = -C linker=aarch64-elf-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0
+doc: export CC = aarch64-elf-gcc.exe
+doc: export AR = aarch64-elf-ar.exe
 doc:
-	# update dependend crates to their latest version if any
-	cargo update
 	# build docu for this crate using custom target
-	xargo doc --lib --no-deps --target $(TARGET) --release --open
-
+	cargo doc --no-deps --target aarch64-unknown-linux-gnu --release --open
+	
 clean:
 	cargo clean

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,41 +1,42 @@
-/*********************************************************************************************************************** 
+/***********************************************************************************************************************
  * Copyright (c) 2019 by the authors
- * 
- * Author: André Borrmann 
+ *
+ * Author: André Borrmann
  * License: Apache License 2.0
  **********************************************************************************************************************/
-#![doc(html_root_url = "https://docs.rs/ruspiro-uart/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/ruspiro-uart/0.3.0")]
 #![no_std]
 #![feature(asm)]
 //! # UART API for Raspberry Pi
-//! 
+//!
 //! This crate provides access to the Uart0 (PL011) and the Uart1 (miniUART) peripheral of the Raspberry Pi. It is quite
 //! helpful during bare metal development to use a terminal console connected to the miniUART of the Raspberry Pi to get
 //! some debug information printed while the program is executed on the device. Especialy if the program is in a state
 //! where there is no other output option or blinking LEDs are not sufficient.
-//! 
+//!
 //! # Example
-//! 
+//!
 //! The proposed usage of the UART is to attach it to a generic console as an output channel instead of using it directly.
 //! To do so, please refer to the [``ruspiro-console`` crate](https://crates.io/crates/ruspiro-console).
-//! 
+//!
 //! But in case you would like to use the uart without the console abstraction it is recommended to wrap it into a singleton
 //! to guaranty safe cross core access and ensure only one time initialization. In the example we pass a fixed core clock rate to
 //! the initialization function. However, the real core clock rate could be optained with a call to the mailbox property
 //! tag interface of the Raspberry Pi (see [``ruspiro-mailbox`` crate](https://crates.io/crates/ruspiro-mailbox) for details.).
-//! 
-//! ```
+//!
+//! ```no_run
 //! use ruspiro_singleton::Singleton; // don't forget the dependency to be setup in ``Cargo.toml``
 //! use ruspiro_uart::Uart1;
-//! 
+//!
 //! static UART: Singleton<Uart1> = Singleton::new(Uart1::new());
-//! 
-//! fn demo() {
-//!     let _ = UART.take_for(|uart| uart.initialize(250_000_000, 115_200)); // initialize(...) gives a Result, you may want to panic if there is an Error returned.
-//! 
+//!
+//! fn main() {
+//!     let _ = UART.take_for(|uart| uart.initialize(250_000_000, 115_200));
+//!     // initialize(...) gives a [Result], you may want to panic if there is an Error returned.
+//!
 //!     print_something("Hello Uart...");
 //! }
-//! 
+//!
 //! fn print_something(s: &str) {
 //!     UART.take_for(|uart| uart.send_string(s));
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,6 @@
 //! }
 //! ```
 
-extern crate alloc;
-
 pub mod uart0;
 #[doc(inline)]
 pub use uart0::*;

--- a/src/uart0/interface.rs
+++ b/src/uart0/interface.rs
@@ -9,7 +9,7 @@
 //! 
 
 use ruspiro_gpio::GPIO;
-use ruspiro_register::{define_registers, RegisterFieldValue};
+use ruspiro_register::{define_mmio_register, RegisterFieldValue};
 use ruspiro_timer as timer;
 
 use crate::UartResult;
@@ -107,19 +107,19 @@ enum Wlen {
     DataLen5    = 0
 }
 
-define_registers![
-    UART0_DR:       ReadWrite<u32> @ UART0_BASE + 0x00,
-    UART0_RSRECR:   ReadWrite<u32> @ UART0_BASE + 0x04,
-    UART0_FR:       ReadWrite<u32> @ UART0_BASE + 0x18 => [
+define_mmio_register![
+    UART0_DR<ReadWrite<u32>@(UART0_BASE + 0x00)>,
+    UART0_RSRECR<ReadWrite<u32>@(UART0_BASE + 0x04)>,
+    UART0_FR<ReadWrite<u32>@(UART0_BASE + 0x18)> {
         TXFE    OFFSET(7),
         RXFF    OFFSET(6),
         TXFF    OFFSET(5),
         RXFE    OFFSET(4),
         BUSY    OFFSET(3)
-    ],
-    UART0_IBRD:     ReadWrite<u32> @ UART0_BASE + 0x24,
-    UART0_FBRD:     ReadWrite<u32> @ UART0_BASE + 0x28,
-    UART0_LCRH:     ReadWrite<u32> @ UART0_BASE + 0x2C => [
+    },
+    UART0_IBRD<ReadWrite<u32>@(UART0_BASE + 0x24)>,
+    UART0_FBRD<ReadWrite<u32>@(UART0_BASE + 0x28)>,
+    UART0_LCRH<ReadWrite<u32>@(UART0_BASE + 0x2C)> {
         SPS     OFFSET(7),
         WLEN    OFFSET(5) BITS(2),
         FEN     OFFSET(4),
@@ -127,8 +127,8 @@ define_registers![
         EPS     OFFSET(2),
         PEN     OFFSET(1),
         BRK     OFFSET(0)
-    ],
-    UART0_CR:       ReadWrite<u32> @ UART0_BASE + 0x30 => [
+    },
+    UART0_CR<ReadWrite<u32>@(UART0_BASE + 0x30)> {
         CTSEN   OFFSET(15),
         RTSEN   OFFSET(14),
         OUT2    OFFSET(13),
@@ -139,12 +139,12 @@ define_registers![
         TXE     OFFSET(8),
         LBE     OFFSET(7),
         UART_EN OFFSET(0)
-    ],
-    UART0_IFLS:     ReadWrite<u32> @ UART0_BASE + 0x34 => [
+    },
+    UART0_IFLS<ReadWrite<u32>@(UART0_BASE + 0x34)> {
         RXIFSEL OFFSET(3) BITS(3),
         TXIFSEL OFFSET(0) BITS(3)
-    ],
-    UART0_IMSC:     ReadWrite<u32> @ UART0_BASE + 0x38 => [
+    },
+    UART0_IMSC<ReadWrite<u32>@(UART0_BASE + 0x38)> {
         INT_OE      OFFSET(10), // Overrun error
         INT_BE      OFFSET(9),
         INT_PE      OFFSET(8),
@@ -155,8 +155,8 @@ define_registers![
         INT_DSRM    OFFSET(3),
         INT_DCDM    OFFSET(2),
         INT_CTSM    OFFSET(1)     
-    ],
-    UART0_RIS:      ReadWrite<u32> @ UART0_BASE + 0x3C,
-    UART0_MIS:      ReadWrite<u32> @ UART0_BASE + 0x40,
-    UART0_ICR:      ReadWrite<u32> @ UART0_BASE + 0x44
+    },
+    UART0_RIS<ReadWrite<u32>@(UART0_BASE + 0x3C)>,
+    UART0_MIS<ReadWrite<u32>@(UART0_BASE + 0x40)>,
+    UART0_ICR<ReadWrite<u32>@(UART0_BASE + 0x44)>
 ];

--- a/src/uart0/interface.rs
+++ b/src/uart0/interface.rs
@@ -1,12 +1,12 @@
-/*********************************************************************************************************************** 
+/***********************************************************************************************************************
  * Copyright (c) 2019 by the authors
- * 
- * Author: André Borrmann 
+ *
+ * Author: André Borrmann
  * License: Apache License 2.0
  **********************************************************************************************************************/
 
 //! # Low-Level Uart0 interface implementation
-//! 
+//!
 
 use ruspiro_gpio::GPIO;
 use ruspiro_register::{define_mmio_register, RegisterFieldValue};
@@ -15,12 +15,11 @@ use ruspiro_timer as timer;
 use crate::UartResult;
 
 // Peripheral MMIO base address - depends on the right feature
-#[cfg(feature="ruspiro_pi3")]
+#[cfg(feature = "ruspiro_pi3")]
 const PERIPHERAL_BASE: u32 = 0x3F00_0000;
 
 // UART0 MMIO base address
-const UART0_BASE: u32 =  PERIPHERAL_BASE + 0x0020_1000;
-
+const UART0_BASE: u32 = PERIPHERAL_BASE + 0x0020_1000;
 
 /// Initialize the Uart0 based on the given core rate and baud rate.
 /// For the time beeing the Uart0 will be bridged to the Raspberry Pi
@@ -33,9 +32,10 @@ pub(crate) fn init(clock_rate: u32, baud_rate: u32) -> UartResult<()> {
         gpio.get_pin(32).map(|pin| pin.to_alt_f3())?;
         gpio.get_pin(33).map(|pin| pin.to_alt_f3())?;
         Ok(())
-    }).and_then(|_| {
-        let baud16:u32 = baud_rate*16;
-        let int_div:u32 = clock_rate / baud16;
+    })
+    .and_then(|_| {
+        let baud16: u32 = baud_rate * 16;
+        let int_div: u32 = clock_rate / baud16;
         let frac_div2 = (clock_rate % baud16) * 8 / baud_rate;
         let frac_div = (frac_div2 / 2) + (frac_div2 % 2);
 
@@ -48,20 +48,20 @@ pub(crate) fn init(clock_rate: u32, baud_rate: u32) -> UartResult<()> {
         UART0_IFLS::Register.write(UART0_IFLS::RXIFSEL, Ifsel::Filled_1_8 as u32);
         UART0_LCRH::Register.write_value(
             RegisterFieldValue::<u32>::new(UART0_LCRH::WLEN, Wlen::DataLen8 as u32)
-            | RegisterFieldValue::<u32>::new(UART0_LCRH::FEN, 0x1)
+                | RegisterFieldValue::<u32>::new(UART0_LCRH::FEN, 0x1),
         );
         UART0_CR::Register.write_value(
-            RegisterFieldValue::<u32>::new(UART0_CR::UART_EN, 0x1) |
-            RegisterFieldValue::<u32>::new(UART0_CR::TXE, 0x1) |
-            RegisterFieldValue::<u32>::new(UART0_CR::RXE, 0x1)
+            RegisterFieldValue::<u32>::new(UART0_CR::UART_EN, 0x1)
+                | RegisterFieldValue::<u32>::new(UART0_CR::TXE, 0x1)
+                | RegisterFieldValue::<u32>::new(UART0_CR::RXE, 0x1),
         );
 
         UART0_IMSC::Register.write_value(
-            RegisterFieldValue::<u32>::new(UART0_IMSC::INT_RX, 0x1) |
-            RegisterFieldValue::<u32>::new(UART0_IMSC::INT_RT, 0x1) |
-            RegisterFieldValue::<u32>::new(UART0_IMSC::INT_OE, 0x1)
+            RegisterFieldValue::<u32>::new(UART0_IMSC::INT_RX, 0x1)
+                | RegisterFieldValue::<u32>::new(UART0_IMSC::INT_RT, 0x1)
+                | RegisterFieldValue::<u32>::new(UART0_IMSC::INT_OE, 0x1),
         );
-        
+
         // UART0 is now ready to be used
         Ok(())
     })
@@ -76,7 +76,9 @@ pub(crate) fn release() {
 
 pub(crate) fn write_byte(data: u8) {
     // wait until Uart0 is ready to accept writes
-    while UART0_FR::Register.read(UART0_FR::TXFF) == 1 { timer::sleepcycles(10); }
+    while UART0_FR::Register.read(UART0_FR::TXFF) == 1 {
+        timer::sleepcycles(10);
+    }
     UART0_DR::Register.set(data as u32);
 }
 
@@ -86,7 +88,9 @@ pub(crate) fn read_byte() -> Option<u8> {
     } else {
         Some((UART0_DR::Register.get() & 0xFF) as u8)
     }*/
-    while UART0_FR::Register.read(UART0_FR::RXFE) == 1 { timer::sleepcycles(10); }
+    while UART0_FR::Register.read(UART0_FR::RXFE) == 1 {
+        timer::sleepcycles(10);
+    }
     Some((UART0_DR::Register.get() & 0xFF) as u8)
 }
 
@@ -96,15 +100,15 @@ enum Ifsel {
     Filled_1_4 = 1,
     Filled_1_2 = 2,
     Filled_3_4 = 3,
-    Filled_7_8 = 4
+    Filled_7_8 = 4,
 }
 
 #[allow(dead_code)]
 enum Wlen {
-    DataLen8    = 3,
-    DataLen7    = 2,
-    DataLen6    = 1,
-    DataLen5    = 0
+    DataLen8 = 3,
+    DataLen7 = 2,
+    DataLen6 = 1,
+    DataLen5 = 0,
 }
 
 define_mmio_register![

--- a/src/uart0/mod.rs
+++ b/src/uart0/mod.rs
@@ -1,15 +1,15 @@
-/*********************************************************************************************************************** 
+/***********************************************************************************************************************
  * Copyright (c) 2019 by the authors
- * 
- * Author: André Borrmann 
+ *
+ * Author: André Borrmann
  * License: Apache License 2.0
  **********************************************************************************************************************/
 
 //! # Uart0 (Pl011) API
-//! 
-//! This is a more fully featured Uart peripheral. In the Raspberry Pi this is most likely configured to act as 
+//!
+//! This is a more fully featured Uart peripheral. In the Raspberry Pi this is most likely configured to act as
 //! communication bridge to other peripherals like the buit in bluetooth low energy chip.
-//! 
+//!
 
 use ruspiro_console::*;
 
@@ -21,57 +21,55 @@ pub struct Uart0 {
 }
 
 impl Uart0 {
-    // get a new Uart0 instance
+    /// get a new Uart0 instance
     pub const fn new() -> Self {
-        Uart0 {
-            initialized: false,
-        }
+        Uart0 { initialized: false }
     }
 
     /// Initialize the Uart0 peripheral for usage. It takes the UART clock rate and the
     /// baud rate to configure correct communication speed. Please not that in the current version the initialization
     /// of the Uart0 will use the GPIO pins 32 and 33 to configure the bridge to the on-board bluetooth low energy chip.
-    /// 
+    ///
     /// # Example
-    /// ```
-    /// # fn demo() {
-    /// let mut uart = Uart1::new();
+    /// ```no_run
+    /// # use ruspiro_uart::uart0::*;
+    /// # fn doc() {
+    /// let mut uart = Uart0::new();
     /// assert_eq!(uart.initialize(3_000_000, 115_200), Ok(()));
     /// # }
     /// ```
-    /// 
     pub fn initialize(&mut self, clock_rate: u32, baud_rate: u32) -> Result<(), &'static str> {
-        interface::init(clock_rate, baud_rate)
-            .map(|_| {
-                self.initialized = true;
-            })
+        interface::init(clock_rate, baud_rate).map(|_| {
+            self.initialized = true;
+        })
     }
 
     /// Write the byte buffer to the Uart0 transmit buffer/fifo which inturn will send the data to any connected device. In the current setup
     /// this is the BLE chip.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// # use ruspiro_uart::uart0::*;
     /// # fn doc() {
-    /// # let uart = Uart0::new();
+    /// # let mut uart = Uart0::new();
     /// # let _ = uart.initialize(3_000_000, 115_200);
     /// let data: [u8; 4] = [1, 15, 20, 10];
     /// uart.write_data(&data);
     /// # }
     /// ```
-    /// 
     pub fn write_data(&self, data: &[u8]) {
         if self.initialized {
-            for d in 0..data.len() {
-                interface::write_byte(data[d]);
+            for byte in data {
+                interface::write_byte(*byte);
             }
         }
     }
 
     /// Read one byte from the Uart0 receive buffer/Fifo if available.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// # use ruspiro_uart::uart0::*;
     /// # fn doc() {
-    /// # let uart = Uart0::new();
+    /// # let mut uart = Uart0::new();
     /// # let _ = uart.initialize(3_000_000, 115_200);
     /// if let Some(data) = uart.read_data() {
     ///     println!("received {}", data);
@@ -87,7 +85,7 @@ impl Uart0 {
     }
 }
 
-// When the Uart0 is dropped it should release the GPIO pins that have been aquired.
+/// When the Uart0 is dropped it should release the GPIO pins that have been aquired.
 impl Drop for Uart0 {
     fn drop(&mut self) {
         // release the GPIO pin's occupied by the Uart0
@@ -95,10 +93,10 @@ impl Drop for Uart0 {
     }
 }
 
-// to use the Uart0 as a console to output strings implement the respective trait
+/// to use the Uart0 as a console to output strings implement the respective trait
 impl ConsoleImpl for Uart0 {
     fn putc(&self, c: char) {
-        let data: [u8;1] = [c as u8];
+        let data: [u8; 1] = [c as u8];
         self.write_data(&data);
     }
 

--- a/src/uart1/interface.rs
+++ b/src/uart1/interface.rs
@@ -1,54 +1,58 @@
-/*********************************************************************************************************************** 
+/***********************************************************************************************************************
  * Copyright (c) 2019 by the authors
- * 
- * Author: André Borrmann 
+ *
+ * Author: André Borrmann
  * License: Apache License 2.0
  **********************************************************************************************************************/
 
 //! # Low-Level UART interface implementation
-//! 
+//!
 
+use ruspiro_gpio::GPIO;
 use ruspiro_register::{define_mmio_register, RegisterFieldValue};
-use ruspiro_gpio::{GPIO, debug::lit_debug_led };
 use ruspiro_timer as timer;
 
 use crate::InterruptType;
 
 // Peripheral MMIO base address - depends on the right feature
-#[cfg(feature="ruspiro_pi3")]
+#[cfg(feature = "ruspiro_pi3")]
 const PERIPHERAL_BASE: u32 = 0x3F00_0000;
 
 // AUX MMIO base address
-const AUX_BASE: u32 =  PERIPHERAL_BASE + 0x0021_5000;
+const AUX_BASE: u32 = PERIPHERAL_BASE + 0x0021_5000;
 
 // initialize the UART1 peripheral of the Raspberry Pi3. This will reserve 2 GPIO pins for UART1 usage.
 // Those pins actually are GPIO14 and 15.
 pub(crate) fn uart1_init(clock_rate: u32, baud_rate: u32) -> Result<(), &'static str> {
-    
     GPIO.take_for(|gpio| {
-        let maybe_tx = gpio.get_pin(14).map(|pin| pin.to_alt_f5().to_pud_disabled());
-        let maybe_ty = gpio.get_pin(15).map(|pin| pin.to_alt_f5().to_pud_disabled());
+        let maybe_tx = gpio
+            .get_pin(14)
+            .map(|pin| pin.to_alt_f5().to_pud_disabled());
+        let maybe_ty = gpio
+            .get_pin(15)
+            .map(|pin| pin.to_alt_f5().to_pud_disabled());
         // returns OK only if both pins could be setup correctly
         maybe_tx.and(maybe_ty)
-    }).map(|_| {
+    })
+    .map(|_| {
         AUX_ENABLES::Register.write(AUX_ENABLES::MINIUART_ENABLE, 0x1); // enable mini UART
         AUX_MU_IER_REG::Register.set(0x0); // disable interrupts
         AUX_MU_CNTL_REG::Register.set(0x0); // disable transmitter and receiver (to set new baud rate)
         AUX_MU_LCR_REG::Register.write(AUX_MU_LCR_REG::DATASIZE, 0x3); // set 8bit data transfer mode
         AUX_MU_MCR_REG::Register.set(0x0); // set UART_RTS line to high (ready to send)
         AUX_MU_IER_REG::Register.set(0x0); // disable interrupts
-        AUX_MU_IIR_REG::Register//.set(0xC6);
-        .write_value(
-            RegisterFieldValue::<u32>::new(AUX_MU_IIR_REG::IRQID_FIFOCLR, 0b11) |
-            RegisterFieldValue::<u32>::new(AUX_MU_IIR_REG::FIFO_ENABLES, 0b11)
-        ); // clear recieve/transmit FIFO, set FIFO as always enabled
-        AUX_MU_BAUD_REG::Register.set(clock_rate/(8*baud_rate)-1); // set the baud rate based on the core clock rate
+        AUX_MU_IIR_REG::Register //.set(0xC6);
+            .write_value(
+                RegisterFieldValue::<u32>::new(AUX_MU_IIR_REG::IRQID_FIFOCLR, 0b11)
+                    | RegisterFieldValue::<u32>::new(AUX_MU_IIR_REG::FIFO_ENABLES, 0b11),
+            ); // clear recieve/transmit FIFO, set FIFO as always enabled
+        AUX_MU_BAUD_REG::Register.set(clock_rate / (8 * baud_rate) - 1); // set the baud rate based on the core clock rate
 
-        AUX_MU_CNTL_REG::Register//.set(0x3);
-        .write_value(
-            RegisterFieldValue::<u32>::new(AUX_MU_CNTL_REG::RCV_ENABLE, 0x1) |
-            RegisterFieldValue::<u32>::new(AUX_MU_CNTL_REG::TRANS_ENABLE, 0x1)
-        ); // enable receiver and transmitter
+        AUX_MU_CNTL_REG::Register //.set(0x3);
+            .write_value(
+                RegisterFieldValue::<u32>::new(AUX_MU_CNTL_REG::RCV_ENABLE, 0x1)
+                    | RegisterFieldValue::<u32>::new(AUX_MU_CNTL_REG::TRANS_ENABLE, 0x1),
+            ); // enable receiver and transmitter
     })
 }
 
@@ -62,7 +66,7 @@ pub(crate) fn uart1_release() {
 
 // send a character string to the UART1 peripheral
 pub(crate) fn uart1_send_char(c: char) {
-    let data: [u8;1] = [c as u8];
+    let data: [u8; 1] = [c as u8];
     uart1_send_data(&data);
 }
 
@@ -75,7 +79,9 @@ pub(crate) fn uart1_send_string(s: &str) {
 pub(crate) fn uart1_send_data(data: &[u8]) {
     for byte in data {
         // wait for the transmitter to be empty
-        while AUX_MU_LSR_REG::Register.read(AUX_MU_LSR_REG::TRANSEMPTY) == 0 { timer::sleepcycles(10); }
+        while AUX_MU_LSR_REG::Register.read(AUX_MU_LSR_REG::TRANSEMPTY) == 0 {
+            timer::sleepcycles(10);
+        }
         AUX_MU_IO_REG::Register.set(*byte as u32);
     }
 }
@@ -85,8 +91,9 @@ pub(crate) fn uart1_send_data(data: &[u8]) {
 // timeout is given in multiples of 1000 CPU cycles
 pub(crate) fn uart1_receive_data(timeout: u32) -> Result<u8, &'static str> {
     let mut count = 0;
-    while AUX_MU_LSR_REG::Register.read(AUX_MU_LSR_REG::DATAREADY) == 0 &&
-        (timeout == 0 || count < timeout) { 
+    while AUX_MU_LSR_REG::Register.read(AUX_MU_LSR_REG::DATAREADY) == 0
+        && (timeout == 0 || count < timeout)
+    {
         timer::sleepcycles(1000);
         count += 1;
     }
@@ -101,21 +108,21 @@ pub(crate) fn uart1_enable_interrupts(i_type: InterruptType) {
     match i_type {
         InterruptType::Receive => {
             AUX_MU_IER_REG::Register.write_value(
-                RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::RCV_IRQ, 0b11) |
-                RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::RX_ENABLE, 0x1)
+                RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::RCV_IRQ, 0b11)
+                    | RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::RX_ENABLE, 0x1),
             );
-        },
+        }
         InterruptType::Transmit => {
             AUX_MU_IER_REG::Register.write_value(
-                RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::RCV_IRQ, 0b11) |
-                RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::TX_ENABLE, 0x1)
+                RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::RCV_IRQ, 0b11)
+                    | RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::TX_ENABLE, 0x1),
             );
-        },
+        }
         InterruptType::RecieveTransmit => {
             AUX_MU_IER_REG::Register.write_value(
-                RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::RCV_IRQ, 0b11) |
-                RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::RX_ENABLE, 0x1) |
-                RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::TX_ENABLE, 0x1)
+                RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::RCV_IRQ, 0b11)
+                    | RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::RX_ENABLE, 0x1)
+                    | RegisterFieldValue::<u32>::new(AUX_MU_IER_REG::TX_ENABLE, 0x1),
             );
         }
     }
@@ -125,10 +132,10 @@ pub(crate) fn uart1_disable_interrupts(i_type: InterruptType) {
     match i_type {
         InterruptType::Receive => {
             AUX_MU_IER_REG::Register.write(AUX_MU_IER_REG::RX_ENABLE, 0x0);
-        },
+        }
         InterruptType::Transmit => {
             AUX_MU_IER_REG::Register.write(AUX_MU_IER_REG::TX_ENABLE, 0x0);
-        },
+        }
         InterruptType::RecieveTransmit => {
             AUX_MU_IER_REG::Register.set(0x0);
         }
@@ -136,8 +143,8 @@ pub(crate) fn uart1_disable_interrupts(i_type: InterruptType) {
 }
 
 pub(crate) fn uart1_get_interrupt_status() -> u32 {
-    AUX_MU_IIR_REG::Register.read(AUX_MU_IIR_REG::IRQPENDING) |
-    (AUX_MU_IIR_REG::Register.read(AUX_MU_IIR_REG::IRQID_FIFOCLR) << 1)
+    AUX_MU_IIR_REG::Register.read(AUX_MU_IIR_REG::IRQPENDING)
+        | (AUX_MU_IIR_REG::Register.read(AUX_MU_IIR_REG::IRQID_FIFOCLR) << 1)
 }
 
 // specify the AUX registers

--- a/src/uart1/mod.rs
+++ b/src/uart1/mod.rs
@@ -1,26 +1,26 @@
-/*********************************************************************************************************************** 
+/***********************************************************************************************************************
  * Copyright (c) 2019 by the authors
- * 
- * Author: André Borrmann 
+ *
+ * Author: André Borrmann
  * License: Apache License 2.0
  **********************************************************************************************************************/
 
 //! # Uart1 (miniUart) API
-//! 
+//!
 //! As per the Raspberry Pi peripheral document the miniUART is a lightweight serial communication channel that does only
 //! need 3 wires (TX, RX, GND) to be connected to the device. The miniUART is typically used to connect the device to
-//! a PC or Mac that runs a terminal console application and is able to display the characters received through this 
+//! a PC or Mac that runs a terminal console application and is able to display the characters received through this
 //! channel. This allows to pass debug information from the device running the bare metal kernel to improve root cause
 //! analysis.
-//! 
+//!
 //! There is no singleton accessor provided for this peripheral as it will be quite likely attached to a ``Console``
 //! abstraction that will than **own** this peripheral and should itself providing exclusive access to the inner accessor
 //! of the actual device. Please refer to the [``ruspiro-console`` crate](https://crates.io/crates/ruspiro-console).
-//! 
+//!
 
 extern crate alloc;
-use ruspiro_console::ConsoleImpl;
 use crate::InterruptType;
+use ruspiro_console::ConsoleImpl;
 
 mod interface;
 
@@ -32,40 +32,44 @@ pub struct Uart1 {
 impl Uart1 {
     /// Get a new Uart1 instance, that needs to be initialized before it can be used.
     /// # Example
+    /// ```no_run
+    /// # use ruspiro_uart::uart1::*;
     /// # fn doc() {
     /// let _miniUart = Uart1::new();
     /// # }
+    /// ```
     pub const fn new() -> Self {
-        Uart1 {
-            initialized: false,
-        }
+        Uart1 { initialized: false }
     }
 
     /// Initialize the Uart1 peripheral for usage. It takes the core clock rate and the
     /// baud rate to configure correct communication speed.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// # use ruspiro_uart::uart1::*;
     /// # fn doc() {
     /// let mut uart = Uart1::new();
     /// assert_eq!(uart.initialize(250_000_000, 115_200), Ok(()));
     /// # }
     /// ```
-    /// 
+    ///
     pub fn initialize(&mut self, clock_rate: u32, baud_rate: u32) -> Result<(), &'static str> {
-        interface::uart1_init(clock_rate, baud_rate)
-            .map(|_| { self.initialized = true; } )
+        interface::uart1_init(clock_rate, baud_rate).map(|_| {
+            self.initialized = true;
+        })
     }
 
     /// Send a single character to the uart peripheral
     /// # Example
-    /// ```
+    /// ```no_run
+    /// # use ruspiro_uart::uart1::*;
     /// # fn doc() {
     /// # let mut uart = Uart1::new();
     /// # let _ = uart.initialize(250_000_000, 115_200);
     /// uart.send_char('A');
     /// # }
     /// ```
-    /// 
+    ///
     pub fn send_char(&self, c: char) {
         if self.initialized {
             interface::uart1_send_char(c);
@@ -74,14 +78,15 @@ impl Uart1 {
 
     /// Send a string to the uart peripheral
     /// # Example
-    /// ```
+    /// ```no_run
+    /// # use ruspiro_uart::uart1::*;
     /// # fn doc() {
     /// # let mut uart = Uart1::new();
     /// # let _ = uart.initialize(250_000_000, 115_200);
     /// uart.send_string("Test string with line break\r\n");
     /// # }
     /// ```
-    /// 
+    ///
     pub fn send_string(&self, s: &str) {
         if self.initialized {
             interface::uart1_send_string(s);
@@ -90,7 +95,8 @@ impl Uart1 {
 
     /// Send a byte buffer to the uart peripheral
     /// # Example
-    /// ```
+    /// ```no_run
+    /// # use ruspiro_uart::uart1::*;
     /// # fn doc() {
     /// # let mut uart = Uart1::new();
     /// # let _ = uart.initialize(20_000_000, 115_200);
@@ -105,7 +111,8 @@ impl Uart1 {
 
     /// convert a given u64 into it's hex representation and send to uart
     /// # Example
-    /// ```
+    /// ```no_run
+    /// # use ruspiro_uart::uart1::*;
     /// # fn doc() {
     /// # let mut uart = Uart1::new();
     /// # let _ = uart.initialize(20_000_000, 115_200);
@@ -115,42 +122,43 @@ impl Uart1 {
     pub fn send_hex(&self, value: u64) {
         if value == 0 {
             self.send_string("0x0");
-            return;    
+            return;
         }
-        const HEXCHAR : &[u8] = "0123456789ABCDEF".as_bytes();
+        const HEXCHAR: &[u8] = b"0123456789ABCDEF";
         let mut tmp = value;
-        let mut hex: [u8;16] = [0; 16];
+        let mut hex: [u8; 16] = [0; 16];
         let mut idx = 0;
         while tmp != 0 {
             hex[idx] = HEXCHAR[(tmp & 0xF) as usize];
-            tmp = tmp >> 4;
-            idx = idx+1;
+            tmp >>= 4;
+            idx += 1;
         }
-        
+
         self.send_string("0x");
         for i in 0..16 {
-            if hex[15-i] != 0 {
-                self.send_char(hex[15-i] as char);
+            if hex[15 - i] != 0 {
+                self.send_char(hex[15 - i] as char);
             }
-        }    
+        }
     }
 
     /// Try to recieve data from the Uart of the given size
     /// If the requested size could be read it returns a ``Ok(data: Vec<u8>)`` containing the data
     /// otherwise an ``Err(msg: &str)``.
-    /// 
+    ///
     /// # Example
-    /// ```
+    /// ```no_run
+    /// # use ruspiro_uart::uart1::*;
     /// # fn doc() {
-    /// # let uart = Uart1::new();
+    /// # let mut uart = Uart1::new();
     /// # let _ = uart.initialize(250_000_000, 115_200);
-    /// let data = uart.try_receive_data(8).expect("unable to receive 8 bytes");
+    /// let mut buffer: [u8; 8] = [0; 8];
+    /// let rx_size = uart.try_receive_data(&mut buffer).expect("unable to receive data");
     /// # }
     /// ```
-    /// 
     pub fn try_receive_data(&self, buffer: &mut [u8]) -> Result<usize, &'static str> {
         if self.initialized {
-            if buffer.len() < 1 {
+            if buffer.is_empty() {
                 Err("buffer size expected to be at least 1")
             } else {
                 for c in 0..buffer.len() {
@@ -164,9 +172,24 @@ impl Uart1 {
         }
     }
 
+    /// Recieve data from the Uart of the given size, blocking the current execution until the
+    /// requested amount if data has been received.
+    /// If the requested size could be read it returns a ``Ok(size: usize)`` containing the data
+    /// otherwise an ``Err(msg: &str)``.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use ruspiro_uart::uart1::*;
+    /// # fn doc() {
+    /// # let mut uart = Uart1::new();
+    /// # let _ = uart.initialize(250_000_000, 115_200);
+    /// let mut buffer: [u8; 8] = [0; 8];
+    /// let rx_size = uart.receive_data(&mut buffer).expect("unable to receive data");
+    /// # }
+    /// ```
     pub fn receive_data(&self, buffer: &mut [u8]) -> Result<usize, &'static str> {
         if self.initialized {
-            if buffer.len() < 1 {
+            if buffer.is_empty() {
                 Err("buffer size expected to be at least 1")
             } else {
                 for c in 0..buffer.len() {
@@ -184,13 +207,16 @@ impl Uart1 {
     /// that shall be triggered. To receive/handle the interrupts a corresponding interrupt handler need to be
     /// implemented, for example by using the [``ruspiro-interrupt`` crate](https://crates.io/crates/ruspiro-interrupt).
     /// # Example
-    /// ```
+    /// ```no_run
+    /// # use ruspiro_uart::InterruptType;
+    /// # use ruspiro_uart::uart1::*;
     /// # fn doc() {
-    /// # let uart = Uart1::new();
+    /// # let mut uart = Uart1::new();
     /// # let _ = uart.initialize(250_000_000, 115_200);
     /// // enable the interrupt to be triggered when data is recieved by the miniUart
     /// uart.enable_interrupts(InterruptType::Receive);
     /// # }
+    /// ```
     pub fn enable_interrupts(&self, i_type: InterruptType) {
         if self.initialized {
             interface::uart1_enable_interrupts(i_type);
@@ -200,13 +226,16 @@ impl Uart1 {
     /// Disable Interrupts from beeing triggered by the miniUart. The ``i_type`` specifies the interrupts
     /// that shall disbabled.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// # use ruspiro_uart::InterruptType;
+    /// # use ruspiro_uart::uart1::*;
     /// # fn doc() {
-    /// # let uart = Uart1::new();
+    /// # let mut uart = Uart1::new();
     /// # let _ = uart.initialize(250_000_000, 115_200);
     /// // disable the interrupt to be triggered when data is recieved by the miniUart
     /// uart.disable_interrupts(InterruptType::Receive);
     /// # }
+    /// ```
     pub fn disable_interrupts(&self, i_type: InterruptType) {
         if self.initialized {
             interface::uart1_disable_interrupts(i_type);
@@ -218,15 +247,17 @@ impl Uart1 {
     /// Bit [1:2] -> 01 = transmit register is empty
     ///              10 = recieve register holds valid data
     /// # Example
-    /// ```
+    /// ```no_run
+    /// # use ruspiro_uart::uart1::*;
     /// # fn doc() {
-    /// # let uart = Uart1::new();
+    /// # let mut uart = Uart1::new();
     /// # let _ = uart.initialize(250_000_000, 115_200);
     /// let irq_status = uart.get_interrupt_status();
     /// if (irq_status & 0b010) != 0 {
     ///     println!("transmit register empty raised");
     /// }
     /// # }
+    /// ```
     pub fn get_interrupt_status(&self) -> u32 {
         if self.initialized {
             interface::uart1_get_interrupt_status()

--- a/src/uart1/mod.rs
+++ b/src/uart1/mod.rs
@@ -95,12 +95,44 @@ impl Uart1 {
     /// # let mut uart = Uart1::new();
     /// # let _ = uart.initialize(20_000_000, 115_200);
     /// uart.send_data("SomeData".as_bytes());
-    /// #}
+    /// # }
     /// ```
     pub fn send_data(&self, d: &[u8]) {
         if self.initialized {
             interface::uart1_send_data(d);
         }
+    }
+
+    /// convert a given u64 into it's hex representation and send to uart
+    /// # Example
+    /// ```
+    /// # fn doc() {
+    /// # let mut uart = Uart1::new();
+    /// # let _ = uart.initialize(20_000_000, 115_200);
+    /// uart.send_hex(12345);
+    /// # }
+    /// ```
+    pub fn send_hex(&self, value: u64) {
+        if value == 0 {
+            self.send_string("0x0");
+            return;    
+        }
+        const HEXCHAR : &[u8] = "0123456789ABCDEF".as_bytes();
+        let mut tmp = value;
+        let mut hex: [u8;16] = [0; 16];
+        let mut idx = 0;
+        while tmp != 0 {
+            hex[idx] = HEXCHAR[(tmp & 0xF) as usize];
+            tmp = tmp >> 4;
+            idx = idx+1;
+        }
+        
+        self.send_string("0x");
+        for i in 0..16 {
+            if hex[15-i] != 0 {
+                self.send_char(hex[15-i] as char);
+            }
+        }    
     }
 
     /// Try to recieve data from the Uart of the given size

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -ev
-
-export CFLAGS='-mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53'
-export RUSTFLAGS='-C linker=arm-linux-gnueabihf-gcc -C target-cpu=cortex-a53 -C target-feature=+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0'
-
-cargo xbuild --target armv7-unknown-linux-gnueabihf --verbose --release --all


### PR DESCRIPTION
enable aarch64 build target and remove `with_allocator` feature that had the only purpose to get forwarded to the `ruspiro_console` crate.